### PR TITLE
Set an soname on libperl.so

### DIFF
--- a/Makefile.config.SH
+++ b/Makefile.config.SH
@@ -139,7 +139,7 @@ cat >> Makefile.config <<END
 LIBPERL_LINK = -Wl,-rpath,\$(archlib)/CORE \$(LIBPERL)
 
 \$(LIBPERL):
-	\$(CC) \$(LDDLFLAGS) -o \$@ \$(filter %\$o,\$^) \$(LIBS)
+	\$(CC) \$(LDDLFLAGS) -Wl,-soname -Wl,libperl.so.${PERL_REVISION}.${PERL_VERSION} -o \$@ \$(filter %\$o,\$^) \$(LIBS)
 END
 else
 cat >> Makefile.config <<"END"


### PR DESCRIPTION
I have split this into two commits so that if you would rather follow upstream and not set an soname, you can just merge the first commit.
