### PR TITLE
Use non-ERE regex for sed operations

### DIFF
--- a/cnf/configure_type.sh
+++ b/cnf/configure_type.sh
@@ -52,7 +52,7 @@ function typesize {
 		return 1
 	fi
 
-	result=`grep foo try.out | sed -e 's/.*: [0-9]\+ \+//' -e 's/ .*//'`
+	result=`grep foo try.out | sed -e 's/.*: [0-9]* *//' -e 's/ .*//'`
 	if [ -z "$result" -o "$result" -le 0 ]; then
 		result "unknown"
 		fail "Can't determine sizeof($_typename)"

--- a/cnf/configure_version.sh
+++ b/cnf/configure_version.sh
@@ -2,7 +2,7 @@
 
 # setverpart name NAME
 function setverpart {
-	_v=`grep '#define' patchlevel.h | grep "$2" | head -1 | sed -e "s/#define $2\s\+//" -e "s/\s.*//"`
+	_v=`grep '#define' patchlevel.h | grep "$2" | head -1 | sed -e "s/#define $2\s*//" -e "s/\s.*//"`
 	msg "	$1=$_v"
 	setvar $1 "$_v"
 }


### PR DESCRIPTION
This fixes using busybox sed on musl libc.