### PR TITLE
Fixes to make code work with ash shell

### DIFF
--- a/0pack.sh
+++ b/0pack.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 # perl-cross, being an overlaid changeset, is not particulary
 # git- or github-friendly.

--- a/Makefile.config.SH
+++ b/Makefile.config.SH
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env sh
 
 if [ ! -f config.sh ]; then
 	echo "config.sh not found" >&2
@@ -39,7 +39,8 @@ if [ "$usecrosscompile" == 'define' ]; then
 	. ./config.sh
 fi
 
-function ifprefixed() {
+ifprefixed()
+{
 	val=`echo "$2" | sed -e "s/^$1//"`
 	if [ "$1$val" == "$2" ]; then
 		echo "\$(CROSS)$val"

--- a/cnf/configure
+++ b/cnf/configure
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env sh
 
 if [ -z "$base" ]; then export base=.; else export base; fi
 config='config.bad'

--- a/cnf/configure__f.sh
+++ b/cnf/configure__f.sh
@@ -1,63 +1,73 @@
-#!/bin/bash
+#!/usr/bin/env sh
 
 # General-purpose functions used by most of other modules
 
 # Note: one-letter variables are "local"
 
-function die {
+die()
+{
 	echo "ERROR: $*" >> $cfglog
 	echo "ERROR: $*" >&2
 	exit 255
 }
 
 # note: setvar()s should preceede result() to produce a nice log
-function result {
+result()
+{
 	echo "Result: $*" >> $cfglog
 	echo >> $cfglog
 	echo "$@" >&2
 }
 
-function log {
+log()
+{
 	echo -e "$@" >> $cfglog
 }
 
-function msg {
+msg()
+{
 	echo -e "$@" >> $cfglog
 	echo -e "$@" >&2
 }
 
-function run {
+run()
+{
 	echo "> $@" >> $cfglog
 	"$@"
 }
 
 # Let user see the whole bunch of errors instead of stopping on the first
-function fail {
+fail()
+{
 	echo "ERROR: $*" >& 2
 	fail=1
 }
 
-function failpoint {
+failpoint()
+{
 	if [ -n "$fail" ]; then
 		exit 255
 	fi
 }
 
-function mstart {
+mstart()
+{
 	echo -e "$@" >> $cfglog
 	echo -ne "$* ... " >& 2
 }
 
 # setenv name value
 # emulates (incorrect in sh) statement $$1="$2"
-function setenv {
+setenv()
+{
 	_z=`echo "$2" | sed -e "s@'@'\"'\"'@g"`
 	eval $1="'$_z'"
 }
 
 # setvar name value
 # emulates (incorrect in sh) statement $$1="$2"
-function setvar {
+setvar()
+{
 	_x=`valueof "$1"`
 	if [ "$_x" != "$2" ]; then
 		setenv "$1" "$2"
@@ -71,7 +81,8 @@ function setvar {
 # $uservars keeps the list of user-set variables
 # $x_(varname) is set to track putvar() calls for this variable
 uservars=''
-function setvaru {
+setvaru()
+{
 	if [ -n "$uservars" ]; then
 		uservars="$uservars $1"
 	else
@@ -91,7 +102,8 @@ function setvaru {
 # putvar name value
 # writes given variable to config, and checks it as
 # "written" if necessary (i.e. for user variables)
-function putvar {
+putvar()
+{
 	_x=`valueof "x_$1"`
 	test -n "$_x" && setenv "x_$1" 'written'
 	_z=`echo "$2" | sed -e "s@'@'\"'\"'@g"`
@@ -99,7 +111,8 @@ function putvar {
 	setvar "$1" "$2"
 }
 
-function setifndef {
+setifndef()
+{
 	v=`valueof "$1"`
 	if [ -z "$v" ]; then
 		setvar "$1" "$2"
@@ -107,7 +120,8 @@ function setifndef {
 }
 
 # archlabel target targetarch -> label
-function archlabel {
+archlabel()
+{
 	if [ -n "$1" -a -n "$2" ]; then
 		echo "$1 ($2)"
 	elif [ -n "$2" ]; then
@@ -119,7 +133,8 @@ function archlabel {
 	fi
 }
 
-function setvardefault {
+setvardefault()
+{
 	v=`valueof "$1"`
 	if [ -z "$v" ]; then
 		setvar "$1" "$2"
@@ -129,31 +144,39 @@ function setvardefault {
 }
 
 # Was more meaningful in the past, but now just a stub.
-function check {
+check()
+{
 	"$@"
 }
 
-function not { if "$@"; then false; else true; fi; }
+not()
+{
+	if "$@"; then false; else true; fi;
+}
 
-function require {
+require()
+{
 	v=`valueof "$1"`
 	if [ -z "$v" ]; then
 		die "Required $1 is not set"
 	fi
 }
 
-function symbolname {
+symbolname()
+{
 	echo "$1" | sed -e 's/^\(struct\|enum\|union\|unsigned\) /s_/'\
 		-e 's/\*/ptr/g' -e 's/\.h$//' -e 's/[^A-Za-z0-9_]//' \
 		-e 's/^s_\(.*\)/\1_s/' -e 's/_//g' |\
 		tr 'A-Z' 'a-z'
 }
 
-function try_start {
+try_start()
+{
 	echo -n > try.c
 }
 
-function try_includes {
+try_includes()
+{
 	for i in "$@"; do 
 		s=i_`symbolname "$i"`
 		v=`valueof "$s"`
@@ -165,33 +188,40 @@ function try_includes {
 	done
 }
 
-function try_add {
+try_add()
+{
 	echo "$@" >> try.c
 }
 
-function try_cat {
+try_cat()
+{
 	cat "$@" >> try.c
 }
 
-function try_dump {
+try_dump()
+{
 	cat try.c | sed -e 's/^/| /' >> $cfglog
 }
 
-function try_dump_out {
+try_dump_out()
+{
 	cat try.out | sed -e 's/^/| /' >> $cfglog
 }
 
-function try_dump_h {
+try_dump_h()
+{
 	cat try.h | sed -e 's/^/| /' >> $cfglog
 }
 
-function try_preproc {
+try_preproc()
+{
 	require 'cpp'
 	#try_dump
 	run $cpp $ccflags try.c > try.out 2>> $cfglog
 }
 
-function try_compile {
+try_compile()
+{
 	require 'cc'
 	require '_o'
 	try_dump
@@ -201,7 +231,8 @@ function try_compile {
 # an equivalent of try_compile with -Werror, but without
 # explicit use of -Werror (which may not be available for
 # a given compiler)
-function try_compile_check_warnings {
+try_compile_check_warnings()
+{
 	require 'cc'
 	require '_o'
 	try_dump
@@ -217,29 +248,34 @@ function try_compile_check_warnings {
 	return 0
 }
 
-function try_link_libs {
+try_link_libs()
+{
 	require 'cc'
 	try_dump
 	run $cc $ccflags -o try$_e try.c $* >> $cfglog 2>&1
 }
 
-function try_link {
+try_link()
+{
 	try_link_libs $libs $*
 }
 
-function try_readelf {
+try_readelf()
+{
 	require 'readelf'
 	require '_o'
 	run $readelf $* try$_o
 }
 
-function try_objdump {
+try_objdump()
+{
 	require 'objdump'
 	require '_o'
 	run $objdump $* try.o > try.out
 }
 
-function isset {
+isset()
+{
 	z=`valueof "$1"`
 	if test -n "$z"; then
 		log "Skipping check for $1, value already set ($z)"
@@ -249,17 +285,25 @@ function isset {
 	fi
 }
 
-function bytes { if [ "$1" == 1 ]; then echo "byte"; else echo "bytes"; fi }
+bytes()
+{
+	if [ "$1" == 1 ]; then echo "byte"; else echo "bytes"; fi
+}
 
-function valueof { eval echo "\"\$$1\""; }
+valueof()
+{
+	eval echo "\"\$$1\"";
+}
 
 # $1=$$2
-function pullval {
+pullval()
+{
 	log "Setting $1 from $2"
 	eval "$1=\"\$$2\""
 }
 
-function ifhint {
+ifhint()
+{
 	h=`valueof "$1"`
 	x=`valueof "x_$1"`
 	test -z "$x" && x='preset'
@@ -272,7 +316,8 @@ function ifhint {
 	fi
 }
 
-function ifhintsilent {
+ifhintsilent()
+{
 	h=`valueof "$1"`
 	x=`valueof "x_$1"`
 	test -z "$x" && x='preset'
@@ -286,11 +331,13 @@ function ifhintsilent {
 
 # just an alias for the above functions, to avoid awkward
 # lines like "if ifhint"
-function hinted {
+hinted()
+{
 	ifhint "$@"
 }
 
-function ifhintdefined {
+ifhintdefined()
+{
 	h=`valueof "$1"`
 	x=`valueof "x_$1"`
 	test -z "$x" && x='preset'
@@ -311,11 +358,19 @@ function ifhintdefined {
 }
 
 # for use in if clauses
-function nothinted { ifhint "$@" && return 1 || return 0; }
-function nohintdefined { ifhintdefined "$@" && return 1 || return 0; }
+nothinted()
+{
+	ifhint "$@" && return 1 || return 0;
+}
+
+nohintdefined()
+{
+	ifhintdefined "$@" && return 1 || return 0;
+}
 
 # resdef result-yes result-no symbol symbol2
-function resdef {
+resdef()
+{
 	if [ $? == 0 ]; then
 		setvar "$3" "define"
 		test -n "$4" && setvar "$4" 'define'
@@ -329,12 +384,14 @@ function resdef {
 	fi	
 }
 
-function modsymname {
+modsymname()
+{
 	echo "$1" | sed -r -e 's!^(ext|cpan|dist|lib)/!!' -e 's![:/-]!_!g' | tr A-Z a-z
 }
 
 # like source but avoid $PATH searches for simple file names
-function sourcenopath {
+sourcenopath()
+{
 	case "$1" in
 		/*) source "$1" ;;
 		*) source "./$1" ;;
@@ -342,7 +399,8 @@ function sourcenopath {
 }
 
 # appendsvar vardst value-to-append
-function appendvar {
+appendvar()
+{
 	v=`valueof "$1"`
 	if [ -n "$v" -a -n "$2" ]; then
 		setvar "$1" "$v $2"
@@ -352,7 +410,8 @@ function appendvar {
 }
 
 # prepend vardst value-to-append
-function prependvar {
+prependvar()
+{
 	v=`valueof "$1"`
 	if [ -n "$v" -a -n "$2" ]; then
 		setvar "$1" "$2 $v"
@@ -361,7 +420,8 @@ function prependvar {
 	fi
 }
 
-function appendvarsilent {
+appendvarsilent()
+{
 	v=`valueof "$1"`
 	test -n "$v" && eval $1="'$v $2'" || eval $1="'$2'"
 }

--- a/cnf/configure_args.sh
+++ b/cnf/configure_args.sh
@@ -1,6 +1,7 @@
-#!/bin/bash
+#!/usr/bin/env sh
 
-function defineyesno {
+defineyesno()
+{
 	if [ "$2" == "yes" ]; then
 		setvaru "$1" "$3"
 	elif [ "$2" == "no" ]; then
@@ -12,11 +13,19 @@ function defineyesno {
 	fi
 }
 
-function defyes { defineyesno "$1" "$2" 'define' 'undef'; }
-function defno  { defineyesno "$1" "$2" 'undef' 'define'; }
+defyes()
+{
+	defineyesno "$1" "$2" 'define' 'undef';
+}
+
+defno()
+{
+	defineyesno "$1" "$2" 'undef' 'define';
+}
 
 # setordefine key hasarg arg default-a default-b
-function setordefine {
+setordefine()
+{
 	if [ -n "$2" ]; then
 		setvaru "$1" "$3"
 	else case "$1" in
@@ -33,22 +42,24 @@ function setordefine {
 }
 
 # pushvar stem value
-function pushnvar {
-	eval n_$1=\$[n_$1+0]
+pushnvar()
+{
+	eval 'n_'$1'=$((n_'$1'+0))'
 	eval n_=\${n_$1}
 	eval $1_$n_="'$2'"
-	eval n_$1=\$[n_$1+1]
+	eval 'n_'$1'=$((n_'$1'+1))'
 	unset -v n_
 }
 
 # pushvar stem key value
-function pushnvarkvx {
-	eval n_$1=\$[n_$1+0]
+pushnvarkvx()
+{
+	eval 'n_'$1'=$((n_'$1'+0))'
 	eval n_=\${n_$1}
 	eval $1_k_$n_="'$2'"
 	eval $1_v_$n_="'$3'"
 	eval $1_x_$n_="'$4'"
-	eval n_$1=\$[n_$1+1]
+	eval 'n_'$1'=$((n_'$1'+1))'
 	unset -v n_
 }
 
@@ -64,7 +75,7 @@ n=''	# next opt
 while [ $i -le $# -o -n "$n" ]; do
 	# in case we've got a short-opt cluster (-abc etc.)
 	if [ -z "$n" ]; then
-		eval a="\${$i}"; i=$[i+1]	# arg ("set" or 'D')
+		eval a="\${$i}"; i=$((i+1))	# arg ("set" or 'D')
 	else
 		a="-$n"
 		n=''
@@ -118,7 +129,7 @@ while [ $i -le $# -o -n "$n" ]; do
 	# fetch argument if necessary (--set foo=bar)
 	# note that non-empty n means there must be no argument
 	if [ -n "$x" -a -z "$k" -a -z "$n" ]; then
-		eval k="\${$i}"; i=$[i+1]
+		eval k="\${$i}"; i=$((i+1))
 	fi
 	# split kv pair into k and v (k=foo v=bar)
 	case "$k" in
@@ -247,10 +258,16 @@ done
 unset -v i a k v x n
 
 # Process -f args (if any) after all options have been parsed
-test -n "$n_loadfile" && for((i=0;i<n_loadfile;i++)); do
-	f=`valueof "loadfile_$i"`
-	sourcenopath $f
-done
+test -n "$n_loadfile" &&
+{
+	i=0
+	while [ $i -lt $n_loadfile ]
+	do
+		f=`valueof "loadfile_$i"`
+		sourcenopath $f
+		i=$((i+1))
+	done
+}
 unset -v i f
 
 # Handle -O

--- a/cnf/configure_attr.sh
+++ b/cnf/configure_attr.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env sh
 
 # Checking compiler's reaction to __attribute__s.
 # Which basically boils down to compiling predefined
@@ -7,7 +7,8 @@
 # checkattr attr <<END
 #    test file goes here
 # END
-function checkattr {
+checkattr()
+{
 	mstart "Checking if compiler supports __attribute__($1)"
 	ifhintdefined "d_attribute_$1" "yes" "no" && return 0
 
@@ -26,7 +27,8 @@ function checkattr {
 # check_if_compiles tag "message" << END
 #     test file goes here
 # END
-function check_if_compiles {
+check_if_compiles()
+{
 	mstart "Checking $2"
 	ifhintdefined "d_$1" "yes" "no" && return 0
 

--- a/cnf/configure_byte.sh
+++ b/cnf/configure_byte.sh
@@ -1,6 +1,7 @@
-#!/bin/bash
+#!/usr/bin/env sh
 
-function byteorder {
+byteorder()
+{
 	mstart "Guessing byte order"
 	ifhint 'byteorder' && return 0
 

--- a/cnf/configure_cfby.sh
+++ b/cnf/configure_cfby.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env sh
 
 # Figure out cf_by and related constants
 

--- a/cnf/configure_clev.sh
+++ b/cnf/configure_clev.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env sh
 
 # Clean the environment
 cleanonly=1

--- a/cnf/configure_dbug.sh
+++ b/cnf/configure_dbug.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env sh
 
 # Handle -DEBUGGING
 mstart "Checking whether to enable -g"

--- a/cnf/configure_defs.sh
+++ b/cnf/configure_defs.sh
@@ -1,7 +1,8 @@
-#!/bin/bash
+#!/usr/bin/env sh
 
 # checkintdefined DEF "includes"
-function checkintdefined {
+checkintdefined()
+{
 	k=`echo "$1" | tr A-Z a-z | sed -e 's/^/d_/'`
 	mstart "Checking whether $1 is defined"
 	ifhint "$k" && return 0
@@ -13,7 +14,8 @@ function checkintdefined {
 }
 
 # checkdefined DEF var "Message" "includes"
-function checkdefinedmsg {
+checkdefinedmsg()
+{
 	mstart "$3"
 	ifhint "$2" && return 0
 	try_start
@@ -26,7 +28,8 @@ function checkdefinedmsg {
 	resdef 'yes' 'no' $2
 }
 
-function checkdefined {
+checkdefined()
+{
 	checkdefinedmsg "$1" "d_$1" "Checking whether $1 is defined in $2" "$2"
 }
 

--- a/cnf/configure_func.sh
+++ b/cnf/configure_func.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env sh
 
 # hasfunc name args includes
 # WARNING: some compilers do have built-in notions on how certain
@@ -6,7 +6,8 @@
 # are called in a "wrong" way. 
 # So far it looks like the safest option is to provide type-compatible arguments,
 # i.e., "0" for ints, "NULL" for pointers etc.
-function hasfunc {
+hasfunc()
+{
 	if [ -n "$4" ] ; then _s="$4"; else _s="d_$1"; fi
 
 	require 'cc'
@@ -29,7 +30,8 @@ function hasfunc {
 # hasvar name includes [symbol]
 # We use try_link here instead of try_compile to be sure we have the
 # variable in question not only declared but also present somewhere in the libraries.
-function hasvar {
+hasvar()
+{
 	if [ -n "$4" ] ; then _s="$4"; else _s="d_$1"; fi
 
 	require 'cc'
@@ -44,7 +46,8 @@ function hasvar {
 	resdef 'found' 'not found' "$_s"
 }
 
-function isvoid {
+isvoid()
+{
 	require 'cc'
 	mstart "Checking whether $1 is void"
 	ifhint "d_$1" && return

--- a/cnf/configure_fung.sh
+++ b/cnf/configure_fung.sh
@@ -1,8 +1,9 @@
-#!/bin/bash
+#!/usr/bin/env sh
 
 # Some guessing after we have all d_funcs ready
 
-function logvars {
+logvars()
+{
 	for i in $*; do
 		v=`valueof $i`
 		log -n "$i=$v "
@@ -10,7 +11,8 @@ function logvars {
 	log ""
 }
 
-function alldefined {
+alldefined()
+{
 	logvars $*
 	for i in $*; do
 		v=`valueof $i`
@@ -98,7 +100,8 @@ fi
 
 
 # checkfpclass func D1 D2 D3 ....
-function checkfpclass {
+checkfpclass()
+{
 	f="$1"; shift
 	v=`valueof "d_$f"`	
 	if [ "$v" == 'define' ]; then

--- a/cnf/configure_genc.sh
+++ b/cnf/configure_genc.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env sh
 
 # Missing variable in config.sh may result in syntactically incorrect
 # config.h (or even more nasty things, if it's in the right part of #define)
@@ -15,7 +15,8 @@ if [ -z "$cleanonly" ]; then
 	# do a real write to $config
 
 	# default name value
-	function default {
+	default()
+	{
 		v=`valueof "$1"`
 		if [ -z "$v" ]; then
 			putvar "$1" "$2"
@@ -24,7 +25,8 @@ if [ -z "$cleanonly" ]; then
 		fi
 	}
 
-	function default_if_defined {
+	default_if_defined()
+	{
 		v=`valueof "$1"`
 		if [ "$v" = "define" ]; then
 			log "$1 is set, setting $2"
@@ -35,7 +37,8 @@ if [ -z "$cleanonly" ]; then
 		fi
 	}
 
-	function default_inst {
+	default_inst()
+	{
 		if [ -n "$2" ]; then
 			z="$2"
 			s="$1"
@@ -52,7 +55,8 @@ if [ -z "$cleanonly" ]; then
 	}
 
 	# required name
-	function required {
+	required()
+	{
 		v=`valueof "$1"`
 		if [ -n "$v" ]; then
 			putvar "$1" "$v"
@@ -61,21 +65,27 @@ if [ -z "$cleanonly" ]; then
 		fi
 	}
 
-	function const {
+	const()
+	{
 		putvar "$1" "$2"
 	}
 
 	test -n "$config" || die "Can't generate don't-know-what (no \$config set)"
 	msg "Generating $config"
-	echo -ne "#!/bin/sh\n\n" > $config
+	echo -ne "#!/usr/bin/env sh\n\n" > $config
 else 
 	# clean up the environment
 
-	function default { unset -v "$1"; }
-	function default_if_defined { unset -v "$1"; }
-	function default_inst { unset -v "$1"; }
-	function required { unset -v "$1"; }
-	function const { unset -v "$1"; }
+	default()
+	{ unset -v "$1"; }
+	default_if_defined()
+	{ unset -v "$1"; }
+	default_inst()
+	{ unset -v "$1"; }
+	required()
+	{ unset -v "$1"; }
+	const()
+	{ unset -v "$1"; }
 fi
 
 required archname
@@ -1189,7 +1199,7 @@ default ssizetype
 default st_ino_sign 1
 default st_ino_size 4
 default startperl "$sharpbang$perlpath"
-default startsh '#!/bin/sh'
+default startsh '#!/usr/bin/env sh'
 default static_ext
 default stdchar char
 default stdio_base

--- a/cnf/configure_hdrs.sh
+++ b/cnf/configure_hdrs.sh
@@ -1,10 +1,11 @@
-#!/bin/bash
+#!/usr/bin/env sh
 
 # We can't really check if header is there (gcc reports no errors for (some?) missing
 # headers). And, in fact, we need not to. All we want to know is whether it's
 # safe to include this header, i.e., that it won't break compilation.
 
-function hashdr {
+hashdr()
+{
 	_hdrname=`symbolname "$1"`
 	
 	mstart "Checking whether to include <$1>"

--- a/cnf/configure_help.sh
+++ b/cnf/configure_help.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env sh
 
 cat <<EOF
 Usage:

--- a/cnf/configure_hint.sh
+++ b/cnf/configure_hint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env sh
 
 # We want to see
 #	var=value
@@ -8,11 +8,12 @@
 # Unlike pretty much any other place in cnf/, the last assignment is
 # effective here.
 
-function tryhints {
+tryhints()
+{
 	hintfile="$base/hints/$1"
 	if [ -f "$hintfile" ]; then
 		msg "	using $hintfile"
-		sed -r -e "/^([A-Za-z0-9_]+)+=/s//happend \1 /" \
+		sed -r -e "/^([A-Za-z0-9_]+)\+=/s//happend \1 /" \
 		       -e "/^([A-Za-z0-9_]+)=/s//hint \1 /"\
 			"$hintfile" > config.hint.tmp
 		. ./config.hint.tmp
@@ -22,12 +23,14 @@ function tryhints {
 	fi
 }
 
-function hint {
+hint()
+{
 	_v=`valueof "$1"`
 	test -z "$_v" && setvaru "$1" "$2" 'hinted'
 }
 
-function happend {
+happend()
+{
 	_v=`valueof "$1"`
 	_s=`valueof "x_$1"`
 	if [ -z "$_v" ]; then
@@ -39,7 +42,8 @@ function happend {
 
 # trypphints prefix hint
 # tries hint then prefix-hint
-function tryphints {
+tryphints()
+{
 	test -n "$2" && tryhints "$2"
 	test -n "$1" -a -n "$2" && tryhints "$1-$2"
 }

--- a/cnf/configure_hinu.sh
+++ b/cnf/configure_hinu.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env sh
 
 # Second part of configure_hint.sh
 # By this point, $cctype may be known, and thus it may be a good
@@ -21,26 +21,33 @@ fi
 log
 
 # Process -A arguments, if any
-test -n "$n_appendlist" && for((i=0;i<n_appendlist;i++)); do
-	k=`valueof "appendlist_k_$i"`
-	v=`valueof "appendlist_v_$i"`
-	x=`valueof "appendlist_x_$i"`
-	if [ -z "$k" -a -n "$v" ]; then
-		k="$v"
-		v=""
-	fi
-	case "$k" in
-		*:*) a=${k/%:*/}; k=${k/#*:/} ;;
-		*) a='append-sp' ;;
-	esac
-	case "$a" in
-		append-sp) setvaru $k "`valueof $k` $v" 'user' ;;
-		append) setvaru $k "`valueof $k`$v" 'user' ;;
-		prepend) setvaru $k "$v`valueof $k`" 'user' ;;
-		define) setordefine "$k" "$x" "$v" 'define' ;;
-		undef) setordefine "$k" "$x" "" 'undef' ;;
-		clear) setvaru $k '' 'user' ;;
-		eval) setvaru $k `eval "$v"` 'user' ;;
-		*) die "Bad -A action $a" ;;
-	esac
-done
+test -n "$n_appendlist" &&
+{
+	i=0
+	while [ $i -lt $n_appendlist ]
+	do
+		k=`valueof "appendlist_k_$i"`
+		v=`valueof "appendlist_v_$i"`
+		x=`valueof "appendlist_x_$i"`
+		if [ -z "$k" -a -n "$v" ]; then
+			k="$v"
+			v=""
+		fi
+		case "$k" in
+			*:*) a=${k/%:*/}; k=${k/#*:/} ;;
+			*) a='append-sp' ;;
+		esac
+		case "$a" in
+			append-sp) setvaru $k "`valueof $k` $v" 'user' ;;
+			append) setvaru $k "`valueof $k`$v" 'user' ;;
+			prepend) setvaru $k "$v`valueof $k`" 'user' ;;
+			define) setordefine "$k" "$x" "$v" 'define' ;;
+			undef) setordefine "$k" "$x" "" 'undef' ;;
+			clear) setvaru $k '' 'user' ;;
+			eval) setvaru $k `eval "$v"` 'user' ;;
+			*) die "Bad -A action $a" ;;
+		esac
+		
+		i=$((i+1))
+	done
+}

--- a/cnf/configure_libs.sh
+++ b/cnf/configure_libs.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env sh
 
 mstart "Deciding whether to use DynaLoader"
 if [ -z "$usedl" ]; then

--- a/cnf/configure_link.sh
+++ b/cnf/configure_link.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env sh
 
 # Names of some variables in Configure are shortened
 # (e.g. i_niin for <netinet/in.h>), and it breaks strict pattern
@@ -9,7 +9,8 @@
 # but this complicates hint/cache reporting and processing.
 
 # linkvar old new
-function linkvar {
+linkvar()
+{
 	eval _v1="\"\$$1\""
 	eval _v2="\"\$$2\""
 	if [ -z "$_v1" ]; then

--- a/cnf/configure_misc.sh
+++ b/cnf/configure_misc.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env sh
 
 # Some final tweaks that do not fit in any other file
 

--- a/cnf/configure_mods.sh
+++ b/cnf/configure_mods.sh
@@ -1,8 +1,9 @@
-#!/bin/bash
+#!/usr/bin/env sh
 
 # Since 5.10.1 the module dirs are flat, so there's no need
 # for recursive search etc.
-function extdir {
+extdir()
+{
 	for i in $1/*; do
 		L=`basename "$i" | sed -e 's!.*-!!'`
 		if [ "$L" == "DynaLoader" ]; then
@@ -18,7 +19,8 @@ function extdir {
 	done
 }
 
-function extadd {
+extadd()
+{
 	s=`modsymname "$2"`
 	if [ "$s" == "dynaloader" ]; then
 		msg "\tskipping $2"
@@ -53,7 +55,8 @@ function extadd {
 	fi
 }
 
-function extadddisabled {
+extadddisabled()
+{
 	s=`modsymname "$2"`
 	if [ "$1" == "xs" ]; then
 		disabled_dynamic_ext="$disabled_dynamic_ext$2 "
@@ -62,7 +65,8 @@ function extadddisabled {
 	fi
 }
 
-function extonlyif {
+extonlyif()
+{
 	m="$1"; shift
 	s=`modsymname "$m"`
 	if [ "$@" ]; then
@@ -75,7 +79,8 @@ function extonlyif {
 
 }
 
-function settrimspaces {
+settrimspaces()
+{
 	_k="$1"
 	_v="$2"
 	_v=`echo "$_v" | sed -r -e 's/\s+/ /g' -e 's/^\s+//' -e 's/\s+$//'`

--- a/cnf/configure_prog.sh
+++ b/cnf/configure_prog.sh
@@ -1,9 +1,10 @@
-#!/bin/bash
+#!/usr/bin/env sh
 
 # Find out which progs to use (mostly by trying prefixes based on $target)
 
 # whichprog msg symbol fail prog1 prog2 ...
-function whichprog {
+whichprog()
+{
 	_what="$1"; shift
 	_symbol="$1"; shift
 	_fail="$1"; shift
@@ -12,7 +13,7 @@ function whichprog {
 	mstart "Checking for $_what"
 
 	if [ -n "$_force" ]; then
-		if which "$_force" >&/dev/null; then
+		if command -v "$_force" 1>/dev/null 2>/dev/null; then
 			setvar "$_symbol" "$_force"
 			result "$_force ($_src)"
 			return 0
@@ -27,7 +28,7 @@ function whichprog {
 	
 	for p in "$@"; do
 		if [ -n "$p" ]; then
-			if which "$p" >&/dev/null; then
+			if command -v "$p" 1>/dev/null 2>/dev/null; then
 				setvar "$_symbol" "$p"
 				result "$p"
 				return 0

--- a/cnf/configure_sigs.sh
+++ b/cnf/configure_sigs.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env sh
 
 # Check which signals we have defined.
 # This may seem a little barbaric, but the whole procedure
@@ -38,7 +38,7 @@ for sig in HUP INT QUIT ILL TRAP ABRT BUS FPE KILL USR1\
 			siginit="$siginit, \"$sig\""
 			signums="$signums $num"
 			signumi="$signumi, $num"
-			sigsize=$[sigsize+1]
+			sigsize=$((sigsize+1))
 		fi
 	fi
 done

--- a/cnf/configure_targ.sh
+++ b/cnf/configure_targ.sh
@@ -1,11 +1,12 @@
-#!/bin/bash
+#!/usr/bin/env sh
 
 # This is called before _gencfg is invoked for the second time
 # to generate tconfig.sh
 # It should forcibly set cc & Co. to some non-cross values.
 # Note: this is *not* tested, and probably can't be.
 
-function setvardefault {
+setvardefault()
+{
 	if [ -n "$2" ]; then
 		setvar "$1" "$2"
 	else
@@ -13,7 +14,8 @@ function setvardefault {
 	fi
 }
 
-function default_tnat {
+default_tnat()
+{
 	v=`valueof "target_$1"`
 	w=`valueof "$1"`
 	if [ -n "$v" -a "$v" != ' ' ]; then

--- a/cnf/configure_thrd.sh
+++ b/cnf/configure_thrd.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env sh
 
 # Thread support
 # Called only if $usethreads is set (which is not by default)
@@ -33,7 +33,8 @@ free_type_letters='T S D R'
 # a pointer to some struct)
 
 # hasfuncr func_r includes 'P_ROTO1 P_ROTO2 ...' 'T=type_T' 'S=type_S' ...
-function hasfuncr {
+hasfuncr()
+{
 	w="$1"
 	D="d_$w"
 	i="pthread.h $2"
@@ -90,7 +91,7 @@ function hasfuncr {
 }
 
 # hasfuncr_assign_types 'T=type_T' 'S=type_S' ...
-function hasfuncr_assign_types
+hasfuncr_assign_types()
 {
 	for cl in $free_type_letters; do 
 		eval "type_$cl='undef'"
@@ -106,7 +107,8 @@ function hasfuncr_assign_types
 }
 
 # hasfuncr_proto func_r 'include.h' P_ROTO 
-function hasfuncr_proto {
+hasfuncr_proto()
+{
 	mstart "\tis it $3"
 	try_start
 	try_includes $2
@@ -123,7 +125,8 @@ function hasfuncr_proto {
 }
 
 # hasfuncr_proto func_r P_ROTO -> "type_P func_r(type_R, type_O, type_T, type_O);"
-function hasfuncr_proto_str {
+hasfuncr_proto_str()
+{
 	cf="$1"
 	cP="$2"
 

--- a/cnf/configure_type.sh
+++ b/cnf/configure_type.sh
@@ -1,9 +1,10 @@
-#!/bin/bash
+#!/usr/bin/env sh
 
 # Check availability of some types, and possibly their size
 
 # hastype name 'includes'
-function hastype {
+hastype()
+{
 	_typename=`symbolname "$1"`
 	
 	mstart "Checking type $1"
@@ -26,7 +27,8 @@ function hastype {
 # to objdump if possible
 
 # typesize name 'includes'
-function typesize {
+typesize()
+{
 	_typename=`symbolname "$1"`
 
 	mstart "Checking size of $1"

--- a/cnf/configure_type_dbl.sh
+++ b/cnf/configure_type_dbl.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env sh
 
 # These tests only provide (unsafe) defaults. Proper values must be hinted.
 

--- a/cnf/configure_type_ext.sh
+++ b/cnf/configure_type_ext.sh
@@ -1,7 +1,8 @@
-#!/bin/bash
+#!/usr/bin/env sh
 
 # hasfield name struct field 'includes'
-function hasfield {
+hasfield()
+{
 	mstart "Checking whether $2 has $3"
 	ifhintdefined "$1" 'yes' 'no' && return 0
 	

--- a/cnf/configure_type_sel.sh
+++ b/cnf/configure_type_sel.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env sh
 
 # After we known what types we have, we've got to chose which
 # of them to use.
@@ -6,7 +6,8 @@
 # typeselect symb required-size it1 ut1 it2 ut2 ...
 # Note: types are always selected in pairs, signed-unsigned,
 # and it's assumed that sizeof(it[j]) == sizeof(ut[j])
-function typeselect () {
+typeselect()
+{
 	_rqsize="$1"; shift
 	_symboli="$1"; shift
 	_symbolu="$1"; shift
@@ -33,7 +34,8 @@ function typeselect () {
 }
 
 # unsigned of type -> unsigned-type
-function unsignedof {
+unsignedof()
+{
 	case "$1" in
 		int*_t) echo "u$1" ;;
 		*) echo "unsigned $1" ;;
@@ -87,7 +89,8 @@ msg "	NV will be "$nvtype", $nvsize bytes"
 
 # typeorfallback base primary-type
 # typeorfallback base primary-type fallback-type
-function typeorfallback {
+typeorfallback()
+{
 	isset "${1}type" && isset "${1}size" && return 0		
 
 	mstart "Looking which type to use as ${1}type"
@@ -168,7 +171,7 @@ fi
 
 mstart "Deciding whether nv preserves full uv"
 if not hinted "d_nv_preserves_uv"; then
-	test $nv_preserves_uv_bits -gt 0 -a $[8*uvsize] == $nv_preserves_uv_bits
+	test $nv_preserves_uv_bits -gt 0 -a $((8*uvsiz)) == $nv_preserves_uv_bits
 	resdef "apparently so" "probably no" d_nv_preserves_uv
 fi
 

--- a/cnf/configure_vars.sh
+++ b/cnf/configure_vars.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env sh
 
 if [ "$mode" == "buildmini" ]; then
 	V="HOST"
@@ -7,7 +7,8 @@ else
 fi
 
 # setfromvar what SHELLVAR
-function setfromvar {
+setfromvar()
+{
 	v=`valueof "$1"`
 	w=`valueof "$V$2"`
 	if [ -z "$v" -a -n "$w" ]; then

--- a/cnf/configure_version.sh
+++ b/cnf/configure_version.sh
@@ -1,7 +1,8 @@
-#!/bin/bash
+#!/usr/bin/env sh
 
 # setverpart name NAME
-function setverpart {
+setverpart()
+{
 	_v=`grep '#define' patchlevel.h | grep "$2" | head -1 | sed -r -e "s/#define $2\s+//" -e "s/\s.*//"`
 	msg "	$1=$_v"
 	setvar $1 "$_v"

--- a/cnf/cpan/Digest/MD5.pm
+++ b/cnf/cpan/Digest/MD5.pm
@@ -1,4 +1,4 @@
-#! /usr/bin/false
+#!/usr/bin/env false
 
 package Digest::MD5;
 use Digest::Perl::MD5 qw(md5 md5_hex md5_base64);

--- a/cnf/cpan/Digest/Perl/MD5.pm
+++ b/cnf/cpan/Digest/Perl/MD5.pm
@@ -1,4 +1,4 @@
-#! /usr/bin/false
+#!/usr/bin/env false
 #
 # $Id: MD5.pm,v 1.19 2004/02/14 02:25:32 lackas Exp $
 #

--- a/configure
+++ b/configure
@@ -1,8 +1,9 @@
-#!/bin/bash
+#!/usr/bin/env sh
 
 root=`dirname "$0"`
 
-function earlydie() {
+earlydie()
+{
 	echo "$@" >&2
 	exit 1
 }

--- a/miniperl_top
+++ b/miniperl_top
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env sh
 
 # This script can be used to run Makefile.PL 
 # Note that is relies on $0 to tell where lib/ is; typically


### PR DESCRIPTION
* Files have had bashisms removed
  * eg for loops, maths, function syntax
* Debianisms removed
  * use of which replaced with command -v, which is portable
* Use of hardcoded path to /bin/sh or /bin/bash removed and replaced
  by /usr/bin/env sh which is extremely portable and allows the user
  to control which shell he wishes to use (important in a cross-
  compile situation where the build machine's shell isn't appropriate)
  (will work now on Solaris, where the shell is in /usr/bin)
* Use of /usr/bin/false likewise switched to /usr/bin/env false
* Sed has been fixed to work correctly when parsing hints using
  BusyBox sed (a '\' escape was missing)
* Going forward, I'd suggest using ${%} glob expressions to replace
  basename and dirname, as these are not 100% portable
* In my local copy, I have changed cnf/hint/linux to remove '-W',
  as this breaks tests for siginfo when compiling against musl