### PR TITLE
minor edits for darwin host support

### DIFF
--- a/Makefile.config.SH
+++ b/Makefile.config.SH
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 if [ ! -f config.sh ]; then
 	echo "config.sh not found" >&2
@@ -19,7 +19,7 @@ if [ "$usecrosscompile" = 'define' ]; then
 		echo 'xconfig.sh not found' >&2
 		exit -1
 	fi
-	
+
 	. ./xconfig.sh
 	hostcc="$cc"
 	hostccflags="$ccflags $optimize"

--- a/Makefile.config.SH
+++ b/Makefile.config.SH
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 if [ ! -f config.sh ]; then
 	echo "config.sh not found" >&2
@@ -8,7 +8,7 @@ fi
 disabledmods=''
 
 . ./config.sh
-echo -n > Makefile.config
+env echo -n > Makefile.config
 if [ "$usecrosscompile" = 'define' ]; then
 	unset cc
 	unset ccflags

--- a/cnf/configure
+++ b/cnf/configure
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 base=${0%/*}; test -z "$base" && base=.
 
@@ -62,7 +62,7 @@ if [ "$mode" = "buildmini" -o "$mode" = "native" ]; then
 fi
 
 if [ -n "$target" -a -z "$targetarch" ]; then
-	mstart "Guessing target architecture"	
+	mstart "Guessing target architecture"
 	targetarch=`$base/config.sub "$target" 2>>$cfglog`
 	if [ -n "$targetarch" ]; then
 		result "$targetarch"
@@ -94,7 +94,7 @@ elif [ "$mode" = "target" ]; then
 	setconfig "config.sh"
 	targetlabel=`archlabel "$target" "$targetarch"`
 	msg "Configuring primary perl executable for $targetlabel"
-elif [ "$mode" = "native" ]; then 
+elif [ "$mode" = "native" ]; then
 	setconfig "config.sh"
 	msg "Configuring for a native build"
 fi

--- a/cnf/configure
+++ b/cnf/configure
@@ -1,9 +1,9 @@
-#!/bin/bash
+#!/bin/sh
 
 base=${0%/*}; test -z "$base" && base=.
 
 cfglog="config.log.$$"
-echo -n > "$cfglog"
+env echo -n > "$cfglog"
 newcfglog() { mv "$cfglog" "$1"; cfglog="$1"; }
 appendlog() { cat "$cfglog" >> "$1"; rm -f "$cfglog"; cfglog="$1"; }
 

--- a/cnf/configure__f.sh
+++ b/cnf/configure__f.sh
@@ -35,8 +35,8 @@ run() {
 # To make nice logs, any define()s should precede result()s.
 
 mstart() {
-	echo "$@" >> $cfglog
-	echo -n "$* ... " >& 2
+	env echo "$@" >> $cfglog
+	env echo -n "$* ... " >& 2
 }
 
 result() {
@@ -184,7 +184,7 @@ gethint() {
 # along with the command used to compile it.
 
 try_start() {
-	echo -n > try.c
+	env echo -n > try.c
 }
 
 try_includes() {

--- a/cnf/configure_type.sh
+++ b/cnf/configure_type.sh
@@ -27,7 +27,7 @@ checktype() {
 checksize() {
 	mstart "Checking size of $2"
 	hinted $1 && return
-	
+
 	try_start
 	try_includes $3
 	try_add "$2 foo;"
@@ -38,13 +38,13 @@ checksize() {
 		return
 	fi
 
-	if not try_readelf -s > try.out 2>>$cfglog; then
+	if not try_readelf --syms > try.out 2>>$cfglog; then
 		result 'unknown'
 		die "Cannot determine sizeof($2), use -D${1}size="
 		return
 	fi
 
-	result=`grep foo try.out | sed -r -e 's/.*: [0-9]+ +//' -e 's/ .*//'`
+	result=`grep foo try.out | sed -r -e 's/.*: [0-9]+ +//' -e 's/ .*//' -e 's/^0+//g'`
 	if [ -z "$result" -o "$result" -le 0 ]; then
 		result "unknown"
 		die "Cannot determine sizeof($2)"


### PR DESCRIPTION
## overview
- use `/bin/bash` in shebang to allow `echo -n`
- `readelf -s` -> `readelf --syms` to allow `gobjdump` as substitute (see wrapper below)
- additional sed substitution to parse `gobjdump` output

## motivation

When using `/bin/sh`, `echo` does not support the `-n` flag which results in it being printed along with the string with undesired effects. `readelf` needs to be replaced with `gobjdump` on Mac, but this doesn't support `-s`, but does allow `--syms` as `readelf` does. (`readelf` with `gcc` 6.4, macports barfs with *"Error: Not an ELF file - it has the wrong magic bytes at the start"* for `try.o`)

## wrapper 
I have a small wrapper called `readelf` in `$PATH` thus:

```bash
#!/bin/bash
exec gobjdump "$@"
```

And similar for `objdump` -> `gobjdump` and `sed` -> `gsed`. 