### PR TITLE
Makefile: Make install.perl depend on install.sym

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -399,7 +399,7 @@ META.yml: Porting/makemeta Porting/Maintainers.pl Porting/Maintainers.pm miniper
 
 install: install.perl install.sym install.man
 
-install.perl: installperl | miniperl$X
+install.perl: installperl install.sym | miniperl$X
 	./miniperl_top installperl --destdir=$(DESTDIR) $(INSTALLFLAGS) $(STRIPFLAGS)
 	-@test ! -s extras.lst || $(MAKE) extras.install
 


### PR DESCRIPTION
Fix a race issue when install, there might be no
$(installbin)/$(perlname)$(version) when install.sym runs after install.perl
since install.sym removes it.

Signed-off-by: Robert Yang <liezhi.yang@windriver.com>