### PR TITLE
In Yocto Project builds we noticed Config_heavy.pl sometimes has lines:

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -202,7 +202,7 @@ configpod: $(CONFIGPOD)
 git_version.h lib/Config_git.pl: make_patchnum.pl | miniperl$X
 	./miniperl_top make_patchnum.pl
 
-lib/Config.pm lib/Config_heavy.pl lib/Config.pod: config.sh \
+lib/Config.pm lib/Config_heavy.pl lib/Config.pod: config.sh cflags \
 		lib/Config_git.pl Porting/Glossary | miniperl$X
 	./miniperl_top configpm
 


### PR DESCRIPTION
cwarnflags=XXX
ccstdflags=XXX

and sometimes does not.

The reason is that this information is pulled from cflags by configpm and yet
there is no dependency in the Makefile.

Add one to fix this.

Signed-off-by: Richard Purdie <richard.purdie@linuxfoundation.org>