### PR TITLE
patches for perl-5.33.1

### DIFF
--- a/cnf/diffs/perl5-5.33.1/constant.patch
+++ b/cnf/diffs/perl5-5.33.1/constant.patch
@@ -1,0 +1,1 @@
+../perl5-5.22.3/constant.patch

--- a/cnf/diffs/perl5-5.33.1/dynaloader.patch
+++ b/cnf/diffs/perl5-5.33.1/dynaloader.patch
@@ -1,0 +1,1 @@
+../perl5-5.22.3/dynaloader.patch

--- a/cnf/diffs/perl5-5.33.1/findext.patch
+++ b/cnf/diffs/perl5-5.33.1/findext.patch
@@ -1,0 +1,1 @@
+../perl5-5.22.3/findext.patch

--- a/cnf/diffs/perl5-5.33.1/installscripts.patch
+++ b/cnf/diffs/perl5-5.33.1/installscripts.patch
@@ -1,0 +1,1 @@
+../perl5-5.30.0/installscripts.patch

--- a/cnf/diffs/perl5-5.33.1/liblist.patch
+++ b/cnf/diffs/perl5-5.33.1/liblist.patch
@@ -1,0 +1,1 @@
+../perl5-5.32.0/liblist.patch

--- a/cnf/diffs/perl5-5.33.1/makemaker.patch
+++ b/cnf/diffs/perl5-5.33.1/makemaker.patch
@@ -1,0 +1,1 @@
+../perl5-5.32.0/makemaker.patch

--- a/cnf/diffs/perl5-5.33.1/posix-makefile.patch
+++ b/cnf/diffs/perl5-5.33.1/posix-makefile.patch
@@ -1,0 +1,1 @@
+../perl5-5.22.3/posix-makefile.patch

--- a/cnf/diffs/perl5-5.33.1/test-checkcase.patch
+++ b/cnf/diffs/perl5-5.33.1/test-checkcase.patch
@@ -1,0 +1,1 @@
+../perl5-5.22.3/test-checkcase.patch

--- a/cnf/diffs/perl5-5.33.1/test-commonsense.patch
+++ b/cnf/diffs/perl5-5.33.1/test-commonsense.patch
@@ -1,0 +1,1 @@
+../perl5-5.26.0/test-commonsense.patch

--- a/cnf/diffs/perl5-5.33.1/xconfig.patch
+++ b/cnf/diffs/perl5-5.33.1/xconfig.patch
@@ -1,0 +1,1 @@
+../perl5-5.28.0/xconfig.patch


### PR DESCRIPTION
I've naively copied diffs from 5.32.0

Works fine for me when cross-compiling to aarch64 using nixpkgs.