### PR TITLE
configure_path.sh: do not hardcode $prefix/lib as library path

### DIFF
--- a/cnf/configure_args.sh
+++ b/cnf/configure_args.sh
@@ -155,7 +155,7 @@ while [ $i -le $# -o -n "$n" ]; do
 		help) mode="help" ;;
 		regen|regenerate) mode="regen" ;;
 		keeplog) defuser "$a" 1 ;;
-		prefix|html[13]dir|libsdir)	defuser $a "$v" ;;
+		prefix|html[13]dir|libsdir|libdir)	defuser $a "$v" ;;
 		man[13]dir|otherlibsdir)	defuser $a "$v" ;;
 		siteprefix|sitehtml[13]dir)	defuser $a "$v" ;;
 		siteman[13]dir|vendorman[13]dir)defuser $a "$v" ;;

--- a/cnf/configure_path.sh
+++ b/cnf/configure_path.sh
@@ -30,6 +30,7 @@ definst() {
 	define "$1" "$installpath$v"
 }
 
+define libdir "$prefix/lib"
 define sharedir "$prefix/share"
 define html1dir "$sharedir/doc/$perlname/html"
 define html3dir "$sharedir/doc/$perlname/html"
@@ -38,16 +39,16 @@ define man1ext "1"
 define man3dir "$sharedir/man/man3"
 define man3ext "3"
 define bin "$prefix/bin"
-define lib "$prefix/lib"
+define lib "$libdir"
 define scriptdir "$prefix/bin"
 define libsdirs ' '
-defrel privlib "$prefix/lib/$package/$version"
-defrel archlib "$prefix/lib/$package/$version/$archname"
+defrel privlib "$libdir/$package/$version"
+defrel archlib "$libdir/$package/$version/$archname"
 define perlpath "$prefix/bin/$perlname"
 define d_archlib 'define'
 
 define sitebin	"$prefix/bin"
-defrel sitelib_stem "$prefix/lib/$package/site_perl"
+defrel sitelib_stem "$libdir/$package/site_perl"
 define sitelib "$sitelib_stem/$version"
 define sitearch "$sitelib_stem/$version/$archname"
 define siteprefix "$prefix"
@@ -145,7 +146,7 @@ vendortest() {
 }
 
 vendorpath vendorbin "$vendorprefix/bin"
-vendorpath vendorlib_stem "$vendorprefix/lib/$package/vendor_perl"
+vendorpath vendorlib_stem "$libdir/$package/vendor_perl"
 vendorpath vendorlib "$vendorlib_stem/$version"
 vendorpath vendorarch "$vendorlib_stem/$version/$archname"
 vendorpath vendorscript "$vendorprefix/bin"


### PR DESCRIPTION
In some environments 'lib' is not actually the desired installation path.