### PR TITLE
cnf/configure_tool.sh: do not filter ldflags when passing them into lddlflags

### DIFF
--- a/cnf/configure_tool.sh
+++ b/cnf/configure_tool.sh
@@ -191,12 +191,8 @@ fi
 if [ -n "$ldflags" -a "$x_lddlflags" != "user" ]; then
 	msg "Checking which flags from \$ldflags to move to \$lddlflags"
 	for f in $ldflags; do
-		case "$f" in
-			-L*|-R*|-Wl,-R*)
-				msg "    added $f"
-				append lddlflags "$f"
-				;;
-		esac
+		msg "    added $f"
+		append lddlflags "$f"
 	done
 fi
 


### PR DESCRIPTION
Yocto has items in there that do not pass the filter,
so it's simpler to just add everything; in yocto this was previously done
with a patch to perl itself, where it would take and apply LDFLAGS
directly - perl upstream pointed out that's not the correct location
to fix the perlcross-specific issue:
https://github.com/Perl-Toolchain-Gang/ExtUtils-MakeMaker/pull/406

With this patch, all flags are correctly passed all the way to the linker:

```
Checking which flags from $ldflags to move to $lddlflags
    added -Wl,-O1
    added -Wl,--hash-style=gnu
    added -Wl,--as-needed
    added -fmacro-prefix-map=/home/alex/development/poky/build-64-alt/tmp/work/core2-64-poky-linux/perl/5.34.0-r0=/usr/src/debug/perl/5.34.0-r0
    added -fdebug-prefix-map=/home/alex/development/poky/build-64-alt/tmp/work/core2-64-poky-linux/perl/5.34.0-r0=/usr/src/debug/perl/5.34.0-r0
    added -fdebug-prefix-map=/home/alex/development/poky/build-64-alt/tmp/work/core2-64-poky-linux/perl/5.34.0-r0/recipe-sysroot=
    added -fdebug-prefix-map=/home/alex/development/poky/build-64-alt/tmp/work/core2-64-poky-linux/perl/5.34.0-r0/recipe-sysroot-native=
    added -Wl,-z,relro,-z,now
```
Signed-off-by: Alexander Kanavin <alex@linutronix.de>