### PR TITLE
new patch for testing ExtUtils-MakeMaker

### DIFF
--- a/cnf/diffs/perl5-5.34.0/test-makemaker.patch
+++ b/cnf/diffs/perl5-5.34.0/test-makemaker.patch
@@ -1,0 +1,17 @@
+The toolchain is not installed on the target when cross-compiling.
+When testing, PERL_CORE is defined, so we need a real compiler check by ExtUtils::Builder.
+
+Revert the commit https://github.com/Perl-Toolchain-Gang/ExtUtils-MakeMaker/commit/5e55318a97616596447c336b9cb331a8dfdc62d5
+which was introduced by ExtUtils-MakeMaker 7.56 in perl 5.33.4
+
+--- a/cpan/ExtUtils-MakeMaker/t/lib/MakeMaker/Test/Utils.pm
++++ b/cpan/ExtUtils-MakeMaker/t/lib/MakeMaker/Test/Utils.pm
+@@ -359,8 +359,6 @@ Returns true if there is a compiler available for XS builds.
+ =cut
+ 
+ sub have_compiler {
+-    return 1 if $ENV{PERL_CORE};
+-
+     my $have_compiler = 0;
+ 
+     in_dir(sub {

--- a/cnf/diffs/perl5-5.35.0/test-makemaker.patch
+++ b/cnf/diffs/perl5-5.35.0/test-makemaker.patch
@@ -1,0 +1,1 @@
+../perl5-5.34.0/test-makemaker.patch

--- a/cnf/diffs/perl5-5.35.1/test-makemaker.patch
+++ b/cnf/diffs/perl5-5.35.1/test-makemaker.patch
@@ -1,0 +1,1 @@
+../perl5-5.34.0/test-makemaker.patch

--- a/cnf/diffs/perl5-5.35.2/test-makemaker.patch
+++ b/cnf/diffs/perl5-5.35.2/test-makemaker.patch
@@ -1,0 +1,1 @@
+../perl5-5.34.0/test-makemaker.patch

--- a/cnf/diffs/perl5-5.35.3/test-makemaker.patch
+++ b/cnf/diffs/perl5-5.35.3/test-makemaker.patch
@@ -1,0 +1,1 @@
+../perl5-5.34.0/test-makemaker.patch

--- a/cnf/diffs/perl5-5.35.4/test-makemaker.patch
+++ b/cnf/diffs/perl5-5.35.4/test-makemaker.patch
@@ -1,0 +1,1 @@
+../perl5-5.34.0/test-makemaker.patch

--- a/cnf/diffs/perl5-5.35.5/test-makemaker.patch
+++ b/cnf/diffs/perl5-5.35.5/test-makemaker.patch
@@ -1,0 +1,1 @@
+../perl5-5.34.0/test-makemaker.patch

--- a/cnf/diffs/perl5-5.35.6/test-makemaker.patch
+++ b/cnf/diffs/perl5-5.35.6/test-makemaker.patch
@@ -1,0 +1,1 @@
+../perl5-5.34.0/test-makemaker.patch

--- a/cnf/diffs/perl5-5.35.7/test-makemaker.patch
+++ b/cnf/diffs/perl5-5.35.7/test-makemaker.patch
@@ -1,0 +1,1 @@
+../perl5-5.34.0/test-makemaker.patch


### PR DESCRIPTION
avoid the following failures:
```
../cpan/ExtUtils-MakeMaker/t/02-xsdynamic.t                        (Wstat: 3072 Tests: 72 Failed: 12)
  Failed tests:  4, 10, 16, 22, 28, 34, 40, 46, 52, 58, 64
                70
  Non-zero exit status: 12
../cpan/ExtUtils-MakeMaker/t/03-xsstatic.t                         (Wstat: 1536 Tests: 36 Failed: 6)
  Failed tests:  4, 10, 16, 22, 28, 34
  Non-zero exit status: 6
```