### PR TITLE
Use ldflags, not lddlflags, in direct library test

### DIFF
--- a/cnf/diffs/perl5-5.24.0/liblist.patch
+++ b/cnf/diffs/perl5-5.24.0/liblist.patch
@@ -48,7 +48,7 @@ Note this is a part of MakeMaker, and only applies to module Makefiles.
 +    warn "Potential libraries are '$potential_libs':\n" if $verbose;
 +
 +    my($ld)   = $Config{ld};
-+    my($lddlflags)   = $Config{lddlflags};
++    my($ldflags)   = $Config{ldflags};
 +    my($libs) = defined $Config{perllibs} ? $Config{perllibs} : $Config{libs};
 +
 +    my $try = 'try_mm.c';
@@ -65,7 +65,7 @@ Note this is a part of MakeMaker, and only applies to module Makefiles.
 +		push(@testlibs, $thislib);
 +		next
 +	};
-+	my $cmd = "$ld $lddlflags -o $tryx $try $testlibs $thislib >/dev/null 2>&1";
++	my $cmd = "$ld $ldflags -o $tryx $try $testlibs $thislib >/dev/null 2>&1";
 +	my $ret = system($cmd);
 +	warn "Warning (mostly harmless): " . "No library found for $thislib\n" if $ret;
 +	next if $ret;

--- a/cnf/diffs/perl5-5.26.0/liblist.patch
+++ b/cnf/diffs/perl5-5.26.0/liblist.patch
@@ -48,7 +48,7 @@ Note this is a part of MakeMaker, and only applies to module Makefiles.
 +    warn "Potential libraries are '$potential_libs':\n" if $verbose;
 +
 +    my($ld)   = $Config{ld};
-+    my($lddlflags)   = $Config{lddlflags};
++    my($ldflags)   = $Config{ldflags};
 +    my($libs) = defined $Config{perllibs} ? $Config{perllibs} : $Config{libs};
 +
 +    my $try = 'try_mm.c';
@@ -65,7 +65,7 @@ Note this is a part of MakeMaker, and only applies to module Makefiles.
 +		push(@testlibs, $thislib);
 +		next
 +	};
-+	my $cmd = "$ld $lddlflags -o $tryx $try $testlibs $thislib >/dev/null 2>&1";
++	my $cmd = "$ld $ldflags -o $tryx $try $testlibs $thislib >/dev/null 2>&1";
 +	my $ret = system($cmd);
 +	warn "Warning (mostly harmless): " . "No library found for $thislib\n" if $ret;
 +	next if $ret;

--- a/cnf/diffs/perl5-5.28.0/liblist.patch
+++ b/cnf/diffs/perl5-5.28.0/liblist.patch
@@ -48,7 +48,7 @@ Note this is a part of MakeMaker, and only applies to module Makefiles.
 +    warn "Potential libraries are '$potential_libs':\n" if $verbose;
 +
 +    my($ld)   = $Config{ld};
-+    my($lddlflags)   = $Config{lddlflags};
++    my($ldflags)   = $Config{ldflags};
 +    my($libs) = defined $Config{perllibs} ? $Config{perllibs} : $Config{libs};
 +
 +    my $try = 'try_mm.c';
@@ -65,7 +65,7 @@ Note this is a part of MakeMaker, and only applies to module Makefiles.
 +		push(@testlibs, $thislib);
 +		next
 +	};
-+	my $cmd = "$ld $lddlflags -o $tryx $try $testlibs $thislib >/dev/null 2>&1";
++	my $cmd = "$ld $ldflags -o $tryx $try $testlibs $thislib >/dev/null 2>&1";
 +	my $ret = system($cmd);
 +	warn "Warning (mostly harmless): " . "No library found for $thislib\n" if $ret;
 +	next if $ret;

--- a/cnf/diffs/perl5-5.32.0/liblist.patch
+++ b/cnf/diffs/perl5-5.32.0/liblist.patch
@@ -48,7 +48,7 @@ Note this is a part of MakeMaker, and only applies to module Makefiles.
 +    warn "Potential libraries are '$potential_libs':\n" if $verbose;
 +
 +    my($ld)   = $Config{ld};
-+    my($lddlflags)   = $Config{lddlflags};
++    my($ldflags)   = $Config{ldflags};
 +    my($libs) = defined $Config{perllibs} ? $Config{perllibs} : $Config{libs};
 +
 +    my $try = 'try_mm.c';
@@ -65,7 +65,7 @@ Note this is a part of MakeMaker, and only applies to module Makefiles.
 +		push(@testlibs, $thislib);
 +		next
 +	};
-+	my $cmd = "$ld $lddlflags -o $tryx $try $testlibs $thislib >/dev/null 2>&1";
++	my $cmd = "$ld $ldflags -o $tryx $try $testlibs $thislib >/dev/null 2>&1";
 +	my $ret = system($cmd);
 +	warn "Warning (mostly harmless): " . "No library found for $thislib\n" if $ret;
 +	next if $ret;

--- a/cnf/diffs/perl5-5.32.1/liblist.patch
+++ b/cnf/diffs/perl5-5.32.1/liblist.patch
@@ -48,7 +48,7 @@ Note this is a part of MakeMaker, and only applies to module Makefiles.
 +    warn "Potential libraries are '$potential_libs':\n" if $verbose;
 +
 +    my($ld)   = $Config{ld};
-+    my($lddlflags)   = $Config{lddlflags};
++    my($ldflags)   = $Config{ldflags};
 +    my($libs) = defined $Config{perllibs} ? $Config{perllibs} : $Config{libs};
 +
 +    my $try = 'try_mm.c';
@@ -65,7 +65,7 @@ Note this is a part of MakeMaker, and only applies to module Makefiles.
 +		push(@testlibs, $thislib);
 +		next
 +	};
-+	my $cmd = "$ld $lddlflags -o $tryx $try $testlibs $thislib >/dev/null 2>&1";
++	my $cmd = "$ld $ldflags -o $tryx $try $testlibs $thislib >/dev/null 2>&1";
 +	my $ret = system($cmd);
 +	warn "Warning (mostly harmless): " . "No library found for $thislib\n" if $ret;
 +	next if $ret;

--- a/cnf/diffs/perl5-5.35.7/liblist.patch
+++ b/cnf/diffs/perl5-5.35.7/liblist.patch
@@ -48,7 +48,7 @@ Note this is a part of MakeMaker, and only applies to module Makefiles.
 +    warn "Potential libraries are '$potential_libs':\n" if $verbose;
 +
 +    my($ld)   = $Config{ld};
-+    my($lddlflags)   = $Config{lddlflags};
++    my($ldflags)   = $Config{ldflags};
 +    my($libs) = defined $Config{perllibs} ? $Config{perllibs} : $Config{libs};
 +
 +    my $try = 'try_mm.c';
@@ -65,7 +65,7 @@ Note this is a part of MakeMaker, and only applies to module Makefiles.
 +		push(@testlibs, $thislib);
 +		next
 +	};
-+	my $cmd = "$ld $lddlflags -o $tryx $try $testlibs $thislib >/dev/null 2>&1";
++	my $cmd = "$ld $ldflags -o $tryx $try $testlibs $thislib >/dev/null 2>&1";
 +	my $ret = system($cmd);
 +	warn "Warning (mostly harmless): " . "No library found for $thislib\n" if $ret;
 +	next if $ret;


### PR DESCRIPTION
With a compiler that can only produce static executables, the previous test would fail because e.g. -shared would end up getting passed here.

I've tested various cross-compilations with this change, both dynamic and static.
