### PR TITLE
cnf/configure_pfmt.sh: add 32 bit integer format definitions

### DIFF
--- a/cnf/configure_pfmt.sh
+++ b/cnf/configure_pfmt.sh
@@ -52,3 +52,9 @@ else
 	define uvxformat '"lx"'
 	define uvXUformat '"lX"'
 fi
+
+define i32dformat 'PRId32'
+define u32uformat 'PRIu32'
+define u32oformat 'PRIo32'
+define u32xformat 'PRIx32'
+define u32XUformat 'PRIX32'


### PR DESCRIPTION
These started to matter in perl 5.38 where they are used to print line numbers.