### PR TITLE
add support for QNX 7.1/8.0

### DIFF
--- a/cnf/configure_tool.sh
+++ b/cnf/configure_tool.sh
@@ -254,6 +254,10 @@ if not hinted 'osname'; then
 			define osname "linux"
 			result "Linux"
 			;;
+		*-nto*)
+			define osname "nto"
+			result "QNX"
+			;;
 		*-netbsd*)
 			define osname "netbsd"
 			result "NetBSD"

--- a/cnf/hints/nto
+++ b/cnf/hints/nto
@@ -1,0 +1,13 @@
+# Linux syscalls
+d_voidsig='define'
+d_nanosleep='define'
+d_clock_gettime='define'
+d_clock_getres='define'
+d_clock_nanosleep='define'
+d_clock='define'
+
+# From the original linux.sh
+usemallocwrap='define'
+
+# libraries to test
+libswanted='m crypt pthread sfio socket inet nsl nm ndbm gdbm dbm db malloc dl dld ld sun sec util c cposix posix ucb BSD gdbm_compat'


### PR DESCRIPTION
**These changes facilitate porting of perl-cross for QNX7.1/8.0.**
Build files are available at https://github.com/qnx-ports/build-files/tree/main/ports/perl5

**NOTE**: QNX ports are only supported from a Linux host operating system

## Create a workspace
```bash
mkdir -p ~/qnx_workspace && cd ~/qnx_workspace
git clone https://github.com/qnx-ports/build-files.git
```

## Clone perl5 and perl-cross repositories from tested release version perl(v5.32.0)/perl-cross(1.6.1)
```bash
git clone https://github.com/qnx-ports/perl5.git
git clone https://github.com/qnx-ports/perl-cross.git
```

## Sync perl-cross project into perl5 main tree
```bash
cd ~/qnx_workspace
rsync -a --force --exclude='.git*' ./perl-cross/ ./perl5/
```

## Pre-requisite:
* Install Docker on Ubuntu
   - https://docs.docker.com/engine/install/ubuntu/
* Install QNX license and SDP installation (~/.qnx and ~/qnx800 by default) 
   - https://www.qnx.com/products/everywhere/ (**Non-Commercial Use**)

## Setup a Docker container

```bash
# Build the Docker image and create a container
cd build-files/docker
./docker-build-qnx-image.sh
./docker-create-container.sh

# Now you are in the Docker container
```

## Or setup Ubuntu host
```bash
# source qnxsdp-env.sh
source ~/qnx800/qnxsdp-env.sh
```

## Compile the port for QNX
```bash
cd ~/qnx_workspace
# Build perl
make -C build-files/ports/perl5 JLEVEL=$(nproc)
# Install it in sysroot (QNX SDP)
make -C build-files/ports/perl5 install
# Or install it in a staging area
make -C build-files/ports/perl5 install INSTALL_ROOT_nto=<PATH_TO_YOUR_STAGING_AREA> USE_INSTALL_ROOT=true
```

## How to run tests
Build perl5 tests and scp it to the target.

```bash
cd ~/qnx_workspace
# Build perl and all tests
make -C build-files/ports/perl5 JLEVEL=$(nproc)

# define target IP address
TARGET_HOST=<target-ip-address-or-hostname>

# remove old test dir on target
ssh qnxuser@$TARGET_HOST "rm -rf perl5_tests"

# create new test dir on target
ssh qnxuser@$TARGET_HOST "mkdir perl5_tests"

# copy perl build tree to your QNX target
scp -r build-files/ports/perl5/nto-aarch64-le/* qnxuser@$TARGET_HOST:/data/home/qnxuser/perl5_tests/
# or
scp -r build-files/ports/perl5/nto-x86_64-o/* qnxuser@$TARGET_HOST:/data/home/qnxuser/perl5_tests/
```

Run tests on the target.
```bash
# ssh into the target
ssh qnxuser@$TARGET_HOST

# setup perl env
cd /data/home/qnxuser/perl5_tests/t && ln -sf ../perl . && LD_LIBRARY_PATH=$(pwd):$LD_LIBRARY_PATH

# run perl tests
./perl harness
# or
./TEST
```

## Tips and triks.

With your spd you can create and run virtual x86_64 TARGET of QNX.
```bash
# source qnxsdp-env.sh
source ~/qnx800/qnxsdp-env.sh

# Install on linux host virtual machine like qemu/vxbox/vmware
# Create and run virtual target of QNX
# qemu
mkqnximage --type=qemu --arch=x86_64 --clean --run --force --data-size=500 --data-inodes=20000
# or vmware
mkqnximage --type=vmware --arch=x86_64 --clean --run --force --data-size=500 --data-inodes=20000
# or virtual box
mkqnximage --type=vbox --arch=x86_64 --clean --run --force --data-size=500 --data-inodes=20000
```

**Note**: Some tests are failed, less then 3% out of all.

### aarch64le:
```bash
Failed 62 tests out of 2376, 97.39% okay.
...
Elapsed: 2284 sec
u=29.22  s=0.16  cu=1719.97  cs=14.78  scripts=2376  tests=953987
```

### x86_64:
```bash
Failed 66 tests out of 2381, 97.23% okay.
...
Elapsed: 1003 sec
u=6.12  s=0.00  cu=431.71  cs=0.00  scripts=2381  tests=959363
```
