### PR TITLE
cnf/configure_mods.sh: sort the module lists

### DIFF
--- a/cnf/configure_mods.sh
+++ b/cnf/configure_mods.sh
@@ -108,7 +108,7 @@ extonlyif() {
 }
 
 definetrimspaces() {
-	v=`echo "$2" | sed -r -e 's/\s+/ /g' -e 's/^\s+//' -e 's/\s+$//'`
+	v=`echo "$2" | sed -r -e 's/\s+/ /g' -e 's/^\s+//' -e 's/\s+$//' | xargs -n1 | LANG=C sort | xargs`
 	define $1 "$v"
 }
 


### PR DESCRIPTION
Sort the order of the module lists from configure_mods.sh since otherwise the result isn't the same leading to makefile differences, and breaks build reproducibility.

Reported upstream: https://github.com/arsv/perl-cross/issues/88