### PR TITLE
cnf/configure: use bash instead of sh

### DIFF
--- a/cnf/configure
+++ b/cnf/configure
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 base=${0%/*}; test -z "$base" && base=.
 


### PR DESCRIPTION
Otherwise trnl gets set to "\n" with bash and "" with dash which leads to different behavior depending on the build host, breaking reproducibility.

Reported: https://github.com/arsv/perl-cross/issues/87