### PR TITLE
configure_pfmt: fix printf format specifiers

### DIFF
--- a/cnf/configure_pfmt.sh
+++ b/cnf/configure_pfmt.sh
@@ -3,28 +3,16 @@
 define d_PRIEUldbl 'undef'
 define d_PRIFUldbl 'undef'
 define d_PRIGUldbl 'undef'
-define d_PRIXU64 'undef'
-define d_PRId64 'undef'
 define d_PRIeldbl 'undef'
 define d_PRIfldbl 'undef'
 define d_PRIgldbl 'undef'
-define d_PRIi64 'undef'
-define d_PRIo64 'undef'
-define d_PRIu64 'undef'
-define d_PRIx64 'undef'
 define d_SCNfldbl 'undef'
 define sPRIEUldbl '"LE"'
 define sPRIFUldbl '"LF"'
 define sPRIGUldbl '"LG"'
-define sPRIXU64 '"LX"'
-define sPRId64 '"Ld"'
 define sPRIeldbl '"Le"'
 define sPRIfldbl '"Lf"'
 define sPRIgldbl '"Lg"'
-define sPRIi64 '"Li"'
-define sPRIo64 '"Lo"'
-define sPRIu64 '"Lu"'
-define sPRIx64 '"Lx"'
 define sSCNfldbl '"Lf"'
 define nvEUformat '"E"'
 define nvFUformat '"F"'
@@ -35,22 +23,58 @@ define nvgformat '"g"'
 define uidformat '"lu"'
 define gidformat '"lu"'
 
-# 64 ints on 32 host should get %Ld instead of %ld.
-# 32 on 32, or 64 on 64, must get regular %ld.
-# This matters for use64bitint builds.
+# Mainline perl Configure implements/-ed a kind of crude stdint.h
+# replacement in case the header is not available. We won't do that.
 
-if [ "$ivsize" -gt "$longsize" ]; then
-	define ivdformat '"Ld"'
-	define uvoformat '"Lo"'
-	define uvuformat '"Lu"'
-	define uvxformat '"Lx"'
-	define uvXUformat '"LX"'
-else
+test "$i_stdint" = 'define' || die "Cannot proceed without <stdint.h>"
+
+define d_PRIXU64 'define'
+define d_PRId64  'define'
+define d_PRIi64  'define'
+define d_PRIo64  'define'
+define d_PRIu64  'define'
+define d_PRIx64  'define'
+
+define sPRIXU64 'PRIX64'
+define sPRId64  'PRId64'
+define sPRIi64  'PRIi64'
+define sPRIo64  'PRIo64'
+define sPRIu64  'PRIu64'
+define sPRIx64  'PRIx64'
+
+if [ "$ivsize" = 8 ]; then
+	define ivdformat "$sPRId64"
+	define uvoformat "$sPRIo64"
+	define uvuformat "$sPRIu64"
+	define uvxformat "$sPRIx64"
+	define uvXUformat "$sPRIXU64"
+elif [ "$ivsize" = "$longsize" ]; then
 	define ivdformat '"ld"'
 	define uvoformat '"lo"'
 	define uvuformat '"lu"'
 	define uvxformat '"lx"'
 	define uvXUformat '"lX"'
+elif [ "$ivsize" = "$intsize" ]; then
+	define ivdformat '"d"'
+	define uvoformat '"o"'
+	define uvuformat '"u"'
+	define uvxformat '"x"'
+	define uvXUformat '"X"'
+elif [ "$ivsize" = "$shortsize" ]; then
+	define ivdformat '"hd"'
+	define uvoformat '"ho"'
+	define uvuformat '"hu"'
+	define uvxformat '"hx"'
+	define uvXUformat '"hX"'
+elif [ "$ivsize" -gt "$longsize" ]; then
+	define ivdformat '"lld"'
+	define uvoformat '"llo"'
+	define uvuformat '"llu"'
+	define uvxformat '"llx"'
+	define uvXUformat '"llX"'
+else
+	msg "Cannot determine printf formats for ${ivsize}-byte iv"
+	exit 1
 fi
 
 define i32dformat 'PRId32'


### PR DESCRIPTION
- use printf format specifiers from `<inttypes.h>`
- fix broken int formats that use `L` instead of `l`/`ll`

fix: https://github.com/arsv/perl-cross/issues/176